### PR TITLE
Fix missed service notifications on all resource unregistrations

### DIFF
--- a/src/poller/mod.rs
+++ b/src/poller/mod.rs
@@ -133,9 +133,9 @@ impl Display for IoType {
 #[derive(Copy, Clone, Debug, Display, Error)]
 #[display(doc_comments)]
 pub enum IoFail {
-    /// connection is absent (POSIX events {0:#b})
+    /// hung up (POSIX events {0:#b})
     Connectivity(i16),
-    /// OS-level error (POSIX events {0:#b})
+    /// errored (POSIX events {0:#b})
     Os(i16),
 }
 


### PR DESCRIPTION
It seems we had the different paths for handling different kind of I/O errors just due to historical reasons. Each of this paths were modified independently in different commits; originally in the case of I/O error we were not disconnecting and just notifying of it the service, letting the service to decide whether a disconnect is needed. Later, we has dropped this notification (probably deciding that the service can't do much in that case) and defaulted to unregistering the resource - but without notifying the service.

This PR brings both cases into a single one, ensuring that (1) we always disconnect on all errors and (2) we always notify the service about the disconnect.