### PR TITLE
chore: Remove unused dependency libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,6 @@ version = "0.5.2"
 dependencies = [
  "amplify",
  "crossbeam-channel",
- "libc",
  "log",
  "mio",
  "polling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ polling = { version = "3.7.2", optional = true }
 # epoll = { version = "4.3.1", optional = true } - NB: epoll not supported on MacOS
 mio = { version = "1.0.0", optional = true }
 log = { version = "0.4.22", optional = true, features = ["kv_unstable"] }
-libc = "0.2.155"
 
 [features]
 default = ["popol"]


### PR DESCRIPTION
The dependency was introduced in 6e59a64 (root commit), and all uses were removed in a7f48fd.